### PR TITLE
Ignore authors when members of team

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: "True/False value to indicate if no labels should be added or removed if the issue already has labels."
     required: false
   team: 
-    description: "Only label issues and pull requests by external contributors. If the author is a team member, the action ignores opened pull requests and issues."
+    description: "Only label issues and pull requests by external contributors. If the author is a team member, the action ignores pull requests and issues that are opened. Use the org and team slug. For example, `octo-org/octokittens`."
     required: false
 branding:
   icon: zap-off

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   ignore-if-labeled:
     description: "True/False value to indicate if no labels should be added or removed if the issue already has labels."
     required: false
+  team: 
+    description: "Only label issues and pull requests by external contributors. If the author is a team member, the action ignores opened pull requests and issues."
+    required: false
 branding:
   icon: zap-off
   color: orange

--- a/label.js
+++ b/label.js
@@ -16,6 +16,7 @@ async function label() {
   const ignoreIfAssigned = core.getInput("ignore-if-assigned");
   const ignoreIfLabeled = core.getInput("ignore-if-labeled");
   const octokit = new github.GitHub(myToken);
+  console.log(context.payload)
   const context = github.context;
   const repoName = context.payload.repository.name;
   const ownerName = context.payload.repository.owner.login;

--- a/label.js
+++ b/label.js
@@ -23,7 +23,7 @@ async function label() {
   console.log(github)
   console.log(context)
   console.log(context.payload)
-  if (context.event_name == 'issues') {
+  if (context.eventName == 'issues') {
     issueNumber = context.payload.issue.number;
   } else {
     issueNumber = context.payload.number;

--- a/label.js
+++ b/label.js
@@ -16,11 +16,16 @@ async function label() {
   const ignoreIfAssigned = core.getInput("ignore-if-assigned");
   const ignoreIfLabeled = core.getInput("ignore-if-labeled");
   const octokit = new github.GitHub(myToken);
-  console.log(context.payload)
   const context = github.context;
   const repoName = context.payload.repository.name;
   const ownerName = context.payload.repository.owner.login;
-  const issueNumber = context.payload.issue.number;
+  const issueNumber;
+  if (context.payload.event_name === 'issues') {
+    issueNumber = context.event.issue.number;
+  } else {
+    issueNumber = context.event.number;
+  }
+  
   const team = core.getInput("team");
 
   // query for the most recent information about the issue. Between the issue being created and

--- a/label.js
+++ b/label.js
@@ -20,7 +20,7 @@ async function label() {
   const repoName = context.payload.repository.name;
   const ownerName = context.payload.repository.owner.login;
   let issueNumber;
-  if (context.eventName == 'issues') {
+  if (context.eventName === "issues") {
     issueNumber = context.payload.issue.number;
   } else {
     issueNumber = context.payload.number;
@@ -29,17 +29,19 @@ async function label() {
 
   // query for the most recent information about the issue. Between the issue being created and
   // the action running, labels or asignees could have been added
-  let updatedIssueInformation = await octokit.issues.get({
+  const updatedIssueInformation = await octokit.issues.get({
     owner: ownerName,
     repo: repoName,
     issue_number: issueNumber
   });
 
   if (team) {
-    const teamArr = team.split("/")
+    const teamArr = team.split("/");
     const org = teamArr.shift();
     const teamSlug = teamArr.pop();
-    const teamMembers = await octokit.request(`/orgs/${org}/teams/${teamSlug}/members`);
+    const teamMembers = await octokit.request(
+      `/orgs/${org}/teams/${teamSlug}/members`
+    );
     const logins = teamMembers.data.map(member => member.login);
     for (let login of logins) {
       if (login === updatedIssueInformation.data.user.login) {

--- a/label.js
+++ b/label.js
@@ -20,7 +20,9 @@ async function label() {
   const repoName = context.payload.repository.name;
   const ownerName = context.payload.repository.owner.login;
   let issueNumber;
-  if (context.event_name === 'issues') {
+  console.log(context.event_name)
+  console.log(context.payload)
+  if (context.event_name == 'issues') {
     issueNumber = context.payload.issue.number;
   } else {
     issueNumber = context.payload.number;

--- a/label.js
+++ b/label.js
@@ -20,10 +20,10 @@ async function label() {
   const repoName = context.payload.repository.name;
   const ownerName = context.payload.repository.owner.login;
   let issueNumber;
-  if (context.payload.event_name === 'issues') {
-    issueNumber = context.event.issue.number;
+  if (context.event_name === 'issues') {
+    issueNumber = context.payload.issue.number;
   } else {
-    issueNumber = context.event.number;
+    issueNumber = context.payload.number;
   }
   const team = core.getInput("team");
 

--- a/label.js
+++ b/label.js
@@ -32,11 +32,13 @@ async function label() {
   console.log(updatedIssueInformation);
 
   if (team) {
-    const org = team.split("/").shift();
+    const teamArr = team.split("/")
+    const org = teamArr.shift();
+    const teamSlug = teamArr.pop();
     console.log(`org: ${org}`);
     const teamMembers = await octokit.teams.listMembersInOrg({
       org: org,
-      team_slug: team
+      team_slug: teamSlug
     });
     const logins = teamMembers.data.map(member => member.login);
     console.log(logins);

--- a/label.js
+++ b/label.js
@@ -20,9 +20,6 @@ async function label() {
   const repoName = context.payload.repository.name;
   const ownerName = context.payload.repository.owner.login;
   let issueNumber;
-  console.log(github)
-  console.log(context)
-  console.log(context.payload)
   if (context.eventName == 'issues') {
     issueNumber = context.payload.issue.number;
   } else {
@@ -37,19 +34,14 @@ async function label() {
     repo: repoName,
     issue_number: issueNumber
   });
-  console.log(updatedIssueInformation);
 
   if (team) {
     const teamArr = team.split("/")
     const org = teamArr.shift();
     const teamSlug = teamArr.pop();
-    console.log(`org: ${org}`);
-    console.log(`teamSlug: ${teamSlug}`)
     const teamMembers = await octokit.request(`/orgs/${org}/teams/${teamSlug}/members`);
     const logins = teamMembers.data.map(member => member.login);
-    console.log(logins);
     for (let login of logins) {
-      console.log(`login: ${login}`);
       if (login === updatedIssueInformation.data.user.login) {
         return `No action being taken. Ignoring because the author of the issue or pull request is part of the ${team} team`;
       }

--- a/label.js
+++ b/label.js
@@ -19,13 +19,12 @@ async function label() {
   const context = github.context;
   const repoName = context.payload.repository.name;
   const ownerName = context.payload.repository.owner.login;
-  const issueNumber;
+  let issueNumber;
   if (context.payload.event_name === 'issues') {
     issueNumber = context.event.issue.number;
   } else {
     issueNumber = context.event.number;
   }
-  
   const team = core.getInput("team");
 
   // query for the most recent information about the issue. Between the issue being created and

--- a/label.js
+++ b/label.js
@@ -37,10 +37,7 @@ async function label() {
     const teamSlug = teamArr.pop();
     console.log(`org: ${org}`);
     console.log(`teamSlug: ${teamSlug}`)
-    const teamMembers = await octokit.teams.listMembersInOrg({
-      org: org,
-      team_slug: teamSlug,
-    });
+    const teamMembers = await octokit.request(`/orgs/${org}/teams/${teamSlug}/members`);
     const logins = teamMembers.data.map(member => member.login);
     console.log(logins);
     for (let login of logins) {

--- a/label.js
+++ b/label.js
@@ -20,7 +20,8 @@ async function label() {
   const repoName = context.payload.repository.name;
   const ownerName = context.payload.repository.owner.login;
   let issueNumber;
-  console.log(context.event_name)
+  console.log(github)
+  console.log(context)
   console.log(context.payload)
   if (context.event_name == 'issues') {
     issueNumber = context.payload.issue.number;

--- a/label.js
+++ b/label.js
@@ -36,9 +36,10 @@ async function label() {
     const org = teamArr.shift();
     const teamSlug = teamArr.pop();
     console.log(`org: ${org}`);
+    console.log(`teamSlug: ${teamSlug}`)
     const teamMembers = await octokit.teams.listMembersInOrg({
       org: org,
-      team_slug: teamSlug
+      team_slug: teamSlug,
     });
     const logins = teamMembers.data.map(member => member.login);
     console.log(logins);


### PR DESCRIPTION
Adds the ability to label newly opened pull requests.

Adds a new input parameter for an organization team. When a team is provided, the action does not label issues and pull requests opened by a team member.