### PR TITLE
Add `needs-fr` label for issues opened by team member

### DIFF
--- a/label.js
+++ b/label.js
@@ -35,7 +35,7 @@ async function label() {
     issue_number: issueNumber
   });
 
-  if (team) {
+  if (team && context.eventName === "pull_request") {
     const teamArr = team.split("/");
     const org = teamArr.shift();
     const teamSlug = teamArr.pop();


### PR DESCRIPTION
Allow `needs-fr` label to be applied when team member opens an issue. 